### PR TITLE
TEST: REPLACE VEGGIE ARRAY VALUES WITH POWERS

### DIFF
--- a/spec/cartoon_collections_spec.rb
+++ b/spec/cartoon_collections_spec.rb
@@ -19,22 +19,22 @@ describe 'Cartoon Collections' do
 
   describe '#summon_captain_planet' do
     it 'returns an array with the same number of elements that it was given' do
-      veggies = %w[carrot cucumber pepper]
-      result = summon_captain_planet(veggies)
+      calls = %w[earth wind fire water heart]
+      result = summon_captain_planet(calls)
       expect(result.class).to eq(Array)
-      expect(result.length).to eq(3)
+      expect(result.length).to eq(5)
     end
 
     it 'capitalizes each element and adds an exclamation mark (test 1)' do
-      fruits = %w[apple banana orange]
-      result = summon_captain_planet(fruits)
-      ['Apple!', 'Banana!', 'Orange!'].each { |w| expect(result).to include w }
+      calls = %w[earth wind fire water heart]
+      result = summon_captain_planet(calls)
+      ['Earth!', 'Wind!', 'Fire!', 'Water!', 'Heart!'].each { |w| expect(result).to include w }
     end
 
     it 'capitalizes each element and adds an exclamation mark (test 2)' do
-      veggies = %w[carrot cucumber pepper]
-      result = summon_captain_planet(veggies)
-      ['Carrot!', 'Cucumber!', 'Pepper!'].each { |w| expect(result).to include w }
+      calls = %w[earth wind fire water heart]
+      result = summon_captain_planet(calls)
+      ['Earth!', 'Wind!', 'Fire!', 'Water!', 'Heart!'].each { |w| expect(result).to include w }
     end
   end
 


### PR DESCRIPTION
The current test values have an array of vegetables, which is confusing in the rspec error print out: students are expecting an array of powers from captain planet, not vegetables.

Replaced the vegetables as values in the test array with powers from captain planet